### PR TITLE
Change proxy host to 0.0.0.0 in .env.docker.dist

### DIFF
--- a/examples/staart/proxy/.env.docker.dist
+++ b/examples/staart/proxy/.env.docker.dist
@@ -1,4 +1,4 @@
-HOST=localhost
+HOST=0.0.0.0
 PORT=8080
 APP_HOST=next:3000
 AUTH_HOST=ooth:3001


### PR DESCRIPTION
In docker the default ip for binding ports is 0.0.0.0, localhost does not work.

Before fix: localhost:8080 was inaccessible when running `npm run bootstrap` , `npm run start:local`
Now: it works as expected.